### PR TITLE
Adds link to slicemasters on homepage

### DIFF
--- a/gatsby/src/components/ItemGrid.js
+++ b/gatsby/src/components/ItemGrid.js
@@ -1,28 +1,47 @@
+import { Link } from 'gatsby';
 import React from 'react';
 import { ItemsGridStyles, SingleItemStyles } from './Grids';
 
-export default function ItemGrid({ items }) {
+/**
+ * Creates a grid of images and names for the main homepage
+ *
+ * baseUrl prop indicates that these items can have links using
+ * the item slugs
+ */
+export default function ItemGrid({ items, baseUrl }) {
+  console.log(items, baseUrl);
   // We can't use Gatsby's image plugin/component, so we'll rely on
   // Sanity's image API to return an image cropped to exact dimensions
   return (
     <ItemsGridStyles>
-      {items.map((item) => (
-        <SingleItemStyles key={item._id}>
-          <p>
-            <span className="mark">{item.name}</span>
-          </p>
-          <img
-            width="500"
-            height="400"
-            src={`${item.image.asset.url}?w=500&h=400&fit=crop`}
-            alt={item.name}
-            style={{
-              background: `url(${item.image.asset.metadata.lqip})`,
-              backgroundSize: 'cover',
-            }}
-          />
-        </SingleItemStyles>
-      ))}
+      {items.map((item) => {
+        // Generate the gridItem without any surrounding links
+        let gridItem = (
+          <SingleItemStyles key={item._id}>
+            <p>
+              <span className="mark">{item.name}</span>
+            </p>
+            <img
+              width="500"
+              height="400"
+              src={`${item.image.asset.url}?w=500&h=400&fit=crop`}
+              alt={item.name}
+              style={{
+                background: `url(${item.image.asset.metadata.lqip})`,
+                backgroundSize: 'cover',
+              }}
+            />
+          </SingleItemStyles>
+        );
+
+        // If this is a linkable item, then wrap it in a link
+        if (baseUrl && item?.slug?.current) {
+          gridItem = (
+            <Link to={`${baseUrl}${item.slug.current}`}>{gridItem}</Link>
+          );
+        }
+        return gridItem;
+      })}
     </ItemsGridStyles>
   );
 }

--- a/gatsby/src/pages/index.js
+++ b/gatsby/src/pages/index.js
@@ -11,7 +11,9 @@ function CurrentlySlicing({ slicemasters }) {
       <p>Ready for action!</p>
       {!slicemasters && <LoadingGrid count={4} />}
       {slicemasters && !slicemasters.length && <p>No one working right now!</p>}
-      {slicemasters?.length && <ItemGrid items={slicemasters} />}
+      {slicemasters?.length && (
+        <ItemGrid items={slicemasters} baseUrl="slicemaster/" />
+      )}
     </div>
   );
 }

--- a/gatsby/src/utils/useStoreSettings.js
+++ b/gatsby/src/utils/useStoreSettings.js
@@ -28,6 +28,9 @@ export default function useStoreSettings() {
               slicemaster {
                 name
                 _id
+                slug {
+                  current
+                }
                 image {
                   asset {
                     url


### PR DESCRIPTION
Since we have pages for individual slicemasters, we may as well link to those pages from the home
page items grid.  (This is issue #1) 

_Note that we do not currently have pages for individual pizzas, so we can't create links for the pizzas on the homepage._

Code changes:
- sanity API call now fetches slicemasters' slug from
useStoreSettings
- ItemGrid now accepts a baseUrl prop which
indicates that the items can have links